### PR TITLE
feat: support jwks with multiple signing algs

### DIFF
--- a/validator/validator.go
+++ b/validator/validator.go
@@ -53,7 +53,7 @@ var allowedSigningAlgorithms = map[jose.SignatureAlgorithm]bool{
 }
 
 // New sets up a new Validator with the required keyFunc
-// and signatureAlgorithm as well as custom options.
+// and list of signatureAlgorithms as well as custom options.
 func New(
 	keyFunc func(context.Context) (interface{}, error),
 	signatureAlgorithms []jose.SignatureAlgorithm,

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/go-jose/go-jose/v4"
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -215,7 +215,7 @@ func TestValidator_ValidateToken(t *testing.T) {
 
 			validator, err := New(
 				testCase.keyFunc,
-				testCase.algorithm,
+				[]jose.SignatureAlgorithm{testCase.algorithm},
 				issuer,
 				[]string{audience, "another-audience"},
 				WithCustomClaims(testCase.customClaims),
@@ -247,32 +247,37 @@ func TestNewValidator(t *testing.T) {
 	}
 
 	t.Run("it throws an error when the keyFunc is nil", func(t *testing.T) {
-		_, err := New(nil, algorithm, issuer, []string{audience})
+		_, err := New(nil, []jose.SignatureAlgorithm{algorithm}, issuer, []string{audience})
 		assert.EqualError(t, err, "keyFunc is required but was nil")
 	})
 
 	t.Run("it throws an error when the signature algorithm is empty", func(t *testing.T) {
-		_, err := New(keyFunc, "", issuer, []string{audience})
+		_, err := New(keyFunc, []jose.SignatureAlgorithm{""}, issuer, []string{audience})
 		assert.EqualError(t, err, "unsupported signature algorithm")
 	})
 
 	t.Run("it throws an error when the signature algorithm is unsupported", func(t *testing.T) {
-		_, err := New(keyFunc, "none", issuer, []string{audience})
+		_, err := New(keyFunc, []jose.SignatureAlgorithm{"none"}, issuer, []string{audience})
+		assert.EqualError(t, err, "unsupported signature algorithm")
+	})
+
+	t.Run("it throws an error when one of the signature algorithms is unsupported", func(t *testing.T) {
+		_, err := New(keyFunc, []jose.SignatureAlgorithm{algorithm, "none"}, issuer, []string{audience})
 		assert.EqualError(t, err, "unsupported signature algorithm")
 	})
 
 	t.Run("it throws an error when the issuerURL is empty", func(t *testing.T) {
-		_, err := New(keyFunc, algorithm, "", []string{audience})
+		_, err := New(keyFunc, []jose.SignatureAlgorithm{algorithm}, "", []string{audience})
 		assert.EqualError(t, err, "issuer url is required but was empty")
 	})
 
 	t.Run("it throws an error when the audience is nil", func(t *testing.T) {
-		_, err := New(keyFunc, algorithm, issuer, nil)
+		_, err := New(keyFunc, []jose.SignatureAlgorithm{algorithm}, issuer, nil)
 		assert.EqualError(t, err, "audience is required but was empty")
 	})
 
 	t.Run("it throws an error when the audience is empty", func(t *testing.T) {
-		_, err := New(keyFunc, algorithm, issuer, []string{})
+		_, err := New(keyFunc, []jose.SignatureAlgorithm{algorithm}, issuer, []string{})
 		assert.EqualError(t, err, "audience is required but was empty")
 	})
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 🔧 Changes

This changes the `validator.New` constructor to accept a slice of `jose.SigningAlgorithm`s instead of a single value. This makes the validator work with JWKS that have keys with different algorithms, which is possible / spec-compliant.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
